### PR TITLE
feat: 支持带有身份认证的网络代理

### DIFF
--- a/app-stream-api/src/main/java/com/dingtalk/open/app/api/OpenDingTalkStreamClientBuilder.java
+++ b/app-stream-api/src/main/java/com/dingtalk/open/app/api/OpenDingTalkStreamClientBuilder.java
@@ -12,8 +12,6 @@ import com.dingtalk.open.app.stream.network.api.NetProxy;
 import com.dingtalk.open.app.stream.network.core.Subscription;
 import com.dingtalk.open.app.stream.protocol.CommandType;
 
-import java.net.InetSocketAddress;
-import java.net.Proxy;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -25,16 +23,15 @@ import java.util.concurrent.ExecutorService;
  * @date 2023/1/3
  */
 public class OpenDingTalkStreamClientBuilder {
-    private int consumeThreads = 16;
     private final Map<CommandType, CommandExecutor> commands = new HashMap<>();
-
     private final Set<Subscription> subscriptions = new HashSet<>();
+    private int consumeThreads = 16;
     private DingTalkCredential credential;
     private int maxConnectionCount = 1;
     private int connectionTimeToLive = 6 * 60 * 60 * 1000;
     private long connectTimeout = 3 * 1000L;
 
-    private Proxy proxy;
+    private NetProxy netProxy;
 
     private KeepAliveOption keepAliveOption = new KeepAliveOption();
 
@@ -115,7 +112,7 @@ public class OpenDingTalkStreamClientBuilder {
      * @return
      */
     public OpenDingTalkStreamClientBuilder proxy(NetProxy netProxy) {
-        this.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(netProxy.getIp(), netProxy.getPort()));
+        this.netProxy = netProxy;
         return this;
     }
 
@@ -140,7 +137,7 @@ public class OpenDingTalkStreamClientBuilder {
         option.setOpenApiHost(openApiHost);
         option.setKeepAliveOption(keepAliveOption);
         ExecutorService executor = ThreadUtil.newFixedExecutor(consumeThreads, "DingTalk-Consumer");
-        return new OpenDingTalkStreamClient(credential, new CommandDispatcher(commands), executor, option, subscriptions, proxy);
+        return new OpenDingTalkStreamClient(credential, new CommandDispatcher(commands), executor, option, subscriptions, netProxy);
     }
 
     private void subscribe(CommandType type, String topic) {

--- a/app-stream-api/src/main/java/com/dingtalk/open/app/api/open/HttpOpenApiClient.java
+++ b/app-stream-api/src/main/java/com/dingtalk/open/app/api/open/HttpOpenApiClient.java
@@ -5,9 +5,11 @@ import com.alibaba.fastjson2.JSONWriter;
 import com.dingtalk.open.app.api.DingTalkAppError;
 import com.dingtalk.open.app.api.open.http.HttpConstants;
 import com.dingtalk.open.app.api.util.IoUtils;
+import com.dingtalk.open.app.stream.network.api.NetProxy;
 
+import java.net.Authenticator;
 import java.net.HttpURLConnection;
-import java.net.Proxy;
+import java.net.PasswordAuthentication;
 import java.net.URL;
 
 /**
@@ -18,23 +20,31 @@ class HttpOpenApiClient implements OpenApiClient {
 
     private final String host;
 
-    private final Proxy proxy;
+    private final NetProxy netProxy;
 
     private final int timeout;
 
-    public HttpOpenApiClient(String host, int timeout, Proxy proxy) {
+    public HttpOpenApiClient(String host, int timeout, NetProxy netProxy) {
         this.host = host;
         this.timeout = timeout;
-        this.proxy = proxy;
+        this.netProxy = netProxy;
     }
 
     @Override
     public OpenConnectionResponse openConnection(OpenConnectionRequest request) throws Exception {
-        URL url =  new URL(host + "/v1.0/gateway/connections/open");
+        URL url = new URL(host + "/v1.0/gateway/connections/open");
 
         HttpURLConnection connection;
-        if (proxy != null) {
-            connection = (HttpURLConnection) url.openConnection(proxy);
+        if (netProxy != null) {
+            if (netProxy.getUsername() != null && netProxy.getPassword() != null) {
+                Authenticator.setDefault(new Authenticator() {
+                    @Override
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        return new PasswordAuthentication(netProxy.getUsername(), netProxy.getPassword().toCharArray());
+                    }
+                });
+            }
+            connection = (HttpURLConnection) url.openConnection(netProxy.getProxy());
         } else {
             connection = (HttpURLConnection) url.openConnection();
         }

--- a/app-stream-api/src/main/java/com/dingtalk/open/app/api/open/OpenApiClientBuilder.java
+++ b/app-stream-api/src/main/java/com/dingtalk/open/app/api/open/OpenApiClientBuilder.java
@@ -1,6 +1,6 @@
 package com.dingtalk.open.app.api.open;
 
-import java.net.Proxy;
+import com.dingtalk.open.app.stream.network.api.NetProxy;
 
 /**
  * @author feiyin
@@ -18,7 +18,7 @@ public class OpenApiClientBuilder {
 
     public String host;
 
-    private Proxy proxy;
+    private NetProxy netProxy;
 
     private int timeout = 3000;
 
@@ -32,12 +32,12 @@ public class OpenApiClientBuilder {
         return this;
     }
 
-    public OpenApiClientBuilder setProxy(Proxy proxy) {
-        this.proxy = proxy;
+    public OpenApiClientBuilder setProxy(NetProxy netProxy) {
+        this.netProxy = netProxy;
         return this;
     }
 
     public OpenApiClient build() {
-        return new HttpOpenApiClient(host, timeout, proxy);
+        return new HttpOpenApiClient(host, timeout, netProxy);
     }
 }

--- a/app-stream-network/app-stream-network-api/src/main/java/com/dingtalk/open/app/stream/network/api/EndPointConnection.java
+++ b/app-stream-network/app-stream-network-api/src/main/java/com/dingtalk/open/app/stream/network/api/EndPointConnection.java
@@ -1,6 +1,5 @@
 package com.dingtalk.open.app.stream.network.api;
 
-import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -13,9 +12,9 @@ public class EndPointConnection {
     private final URI endPoint;
     private final String connectionId;
 
-    private final Proxy proxy;
+    private final NetProxy netProxy;
 
-    public EndPointConnection(String clientId, String endPoint, String connectionId, Proxy proxy) {
+    public EndPointConnection(String clientId, String endPoint, String connectionId, NetProxy netProxy) {
         this.clientId = clientId;
         try {
             this.endPoint = new URI(endPoint);
@@ -23,7 +22,7 @@ public class EndPointConnection {
             throw new RuntimeException(e);
         }
         this.connectionId = connectionId;
-        this.proxy = proxy;
+        this.netProxy = netProxy;
     }
 
     public URI getEndPoint() {
@@ -42,7 +41,7 @@ public class EndPointConnection {
         return TransportProtocol.parseScheme(endPoint.getScheme());
     }
 
-    public Proxy getProxy() {
-        return proxy;
+    public NetProxy getNetProxy() {
+        return netProxy;
     }
 }

--- a/app-stream-network/app-stream-network-api/src/main/java/com/dingtalk/open/app/stream/network/api/NetProxy.java
+++ b/app-stream-network/app-stream-network-api/src/main/java/com/dingtalk/open/app/stream/network/api/NetProxy.java
@@ -1,23 +1,47 @@
 package com.dingtalk.open.app.stream.network.api;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
 /**
  * @author feiyin
  * @date 2023/11/21
  */
 public class NetProxy {
-    private String host;
-    private Integer port;
+    private final String host;
+    private final Integer port;
+    private String username;
+    private String password;
 
     public NetProxy(String host, Integer port) {
         this.host = host;
         this.port = port;
     }
 
-    public String getIp() {
+    public NetProxy(String host, Integer port, String username, String password) {
+        this.host = host;
+        this.port = port;
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getHost() {
         return host;
     }
 
     public Integer getPort() {
         return port;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public Proxy getProxy() {
+        return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(host, port));
     }
 }


### PR DESCRIPTION
解决带有身份认证的网络代理在进行 websocket 连接时的认证问题；
tips：jdk8 的更新对网络代理的身份认证部分有更新 
> Disable Basic authentication for HTTPS tunneling
https://www.oracle.com/java/technologies/javase/8u111-relnotes.html

可以参考如下方案解决：
https://stackoverflow.com/questions/41806422/java-web-start-unable-to-tunnel-through-proxy-since-java-8-update-111