### PR TITLE
钉钉Stream支持全球化

### DIFF
--- a/app-stream-api/src/main/java/com/dingtalk/open/app/api/UserAgent.java
+++ b/app-stream-api/src/main/java/com/dingtalk/open/app/api/UserAgent.java
@@ -20,7 +20,7 @@ public class UserAgent {
     }
 
     public String getUa() {
-        return this.name + "/" + this.version;
+        return this.name + "/" + this.version + "-union";
     }
 
 }


### PR DESCRIPTION
钉钉Stream支持全球化，ua增加-union方便服务端识别后，分发不同域名。
同时兼容老的版本，老版本域名保持不变，然后新带union标识会用一个全新的域名