### PR TITLE
feat: add oversea region support for DingTalk Stream SDK

### DIFF
--- a/app-stream-api/src/main/java/com/dingtalk/open/app/api/OpenDingTalkStreamClientBuilder.java
+++ b/app-stream-api/src/main/java/com/dingtalk/open/app/api/OpenDingTalkStreamClientBuilder.java
@@ -106,9 +106,9 @@ public class OpenDingTalkStreamClientBuilder {
     }
 
     /**
-     * 使用海外版钉钉正式环境
+     * 使用海外DingTalk正式环境
      * <p>
-     * 海外纯血版钉钉用户请使用此方法，API地址将切换为 https://api.dingtalk.io
+     * 海外DingTalk用户请使用此方法，API地址将切换为 https://api.dingtalk.io
      * </p>
      *
      * @return builder
@@ -118,9 +118,9 @@ public class OpenDingTalkStreamClientBuilder {
     }
 
     /**
-     * 使用海外版钉钉预发环境
+     * 使用海外DingTalk预发环境
      * <p>
-     * 海外纯血版钉钉用户预发环境，API地址将切换为 https://pre-api.dingtalk.io
+     * 海外DingTalk用户预发环境，API地址将切换为 https://pre-api.dingtalk.io
      * </p>
      *
      * @return builder

--- a/app-stream-api/src/main/java/com/dingtalk/open/app/api/OpenDingTalkStreamClientBuilder.java
+++ b/app-stream-api/src/main/java/com/dingtalk/open/app/api/OpenDingTalkStreamClientBuilder.java
@@ -106,6 +106,30 @@ public class OpenDingTalkStreamClientBuilder {
     }
 
     /**
+     * 使用海外版钉钉正式环境
+     * <p>
+     * 海外纯血版钉钉用户请使用此方法，API地址将切换为 https://api.dingtalk.io
+     * </p>
+     *
+     * @return builder
+     */
+    public OpenDingTalkStreamClientBuilder oversea() {
+        return this.openApiHost("https://api.dingtalk.io");
+    }
+
+    /**
+     * 使用海外版钉钉预发环境
+     * <p>
+     * 海外纯血版钉钉用户预发环境，API地址将切换为 https://pre-api.dingtalk.io
+     * </p>
+     *
+     * @return builder
+     */
+    public OpenDingTalkStreamClientBuilder overseaPreEnv() {
+        return this.openApiHost("https://pre-api.dingtalk.io");
+    }
+
+    /**
      * 设置代理方式
      *
      * @param netProxy


### PR DESCRIPTION
Add oversea() and overseaPreEnv() methods to OpenDingTalkStreamClientBuilder, allowing users to switch API endpoint to https://api.dingtalk.io and https://pre-api.dingtalk.io for overseas DingTalk users.